### PR TITLE
Fix path split.

### DIFF
--- a/autoload/marching.vim
+++ b/autoload/marching.vim
@@ -36,7 +36,7 @@ endfunction
 
 
 function! marching#get_include_dirs()
-	return filter(split(&path, ',') + g:marching_include_paths, 'isdirectory(v:val) && v:val !~ ''\./''')
+	return filter(map(split(&path, '\\\@<![, ]'), 'substitute(v:val, ''\\\([, ]\)'', ''\1'', ''g'')') + g:marching_include_paths, 'isdirectory(v:val) && v:val !~ ''\./''')
 endfunction
 
 

--- a/autoload/marching/clang_command.vim
+++ b/autoload/marching/clang_command.vim
@@ -4,7 +4,7 @@ set cpo&vim
 
 
 function! s:include_opt()
-	let include_opt = join(filter(marching#get_include_dirs(), 'v:val !=# "."'), ' -I')
+	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'string(v:val)'), ' -I')
 	if empty(include_opt)
 		return ""
 	endif

--- a/autoload/marching/complete.vim
+++ b/autoload/marching/complete.vim
@@ -56,7 +56,7 @@ endfunction
 
 
 function! s:include_opt()
-	let include_opt = join(filter(split(&path, ',') + g:marching_include_paths, 'isdirectory(v:val) && v:val !~ ''\./'''), ' -I')
+	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'string(v:val)'), ' -I')
 	if empty(include_opt)
 		return ""
 	endif


### PR DESCRIPTION
`&path`の分割は単純に`,`で分割しただけでは` `(スペース)や`,`を含む場合正常に動作しないので修正しました

> :help 'path'
> 
>  区切りには空白も使える (Vim version 3.0 との後方互換性のため)。中に
>  空白を含んだディレクトリ名を指定するには、空白の前に余分に '\' {訳注:
>  |option-backslash| を参照} を置き、その上で空白と '\' を '\' でエス
>  ケープすること。
> 
> ``` vim
> :set path=.,/dir/with\\\ space
> {訳注: 結果は ".,/dir/with\ space"}
> ```
> 
>  中にコンマを含んだディレクトリ名を指定するには、コンマの前に余分に
>  '\' を置き、その上で '\' を '\' でエスケープすること。
> 
> ``` vim
> :set path=.,/dir/with\\,comma
> {訳注: 結果は ".,/dir/with\,comma"}
> ```
