### PR TITLE
Fix path escape.

### DIFF
--- a/autoload/marching/clang_command.vim
+++ b/autoload/marching/clang_command.vim
@@ -4,7 +4,7 @@ set cpo&vim
 
 
 function! s:include_opt()
-	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'string(v:val)'), ' -I')
+	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'shellescape(v:val)'), ' -I')
 	if empty(include_opt)
 		return ""
 	endif

--- a/autoload/marching/complete.vim
+++ b/autoload/marching/complete.vim
@@ -56,7 +56,7 @@ endfunction
 
 
 function! s:include_opt()
-	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'string(v:val)'), ' -I')
+	let include_opt = join(map(filter(marching#get_include_dirs(), 'v:val !=# "."'), 'shellescape(v:val)'), ' -I')
 	if empty(include_opt)
 		return ""
 	endif


### PR DESCRIPTION
#5 のコメントで書いたように`string()`だと`'`の扱いが違い、

`g:marching_backend = 'sync_clang_command'`かつvimprocが無い状態だと候補が出なかったので
`shellescape()`に変更しました
